### PR TITLE
Fix issue where Rails application name was being evaluated to nil

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    token_validator (0.3.0)
+    token_validator (0.3.1)
       jose
       json-jwt
       jwt

--- a/lib/token_validator/version.rb
+++ b/lib/token_validator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TokenValidator
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

*Why?*

There was a caching issue in local development environments affecting access tokens due to the cache namespace constant being evaluated before the Rails application had been loaded.

*How?*

Move the logic that was attempting to get the cache namespace to a private helper method.

*Risks*

Low

*Requested Reviewers*

@bcarr092 @dragoszt @ValentinJarryZT 
