### PR TITLE
fix: Change the way production is checked for.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    token_validator (0.3.1)
+    token_validator (0.3.2)
       jose
       json-jwt
       jwt
@@ -112,7 +112,7 @@ GEM
     minitest (5.11.3)
     netrc (0.11.0)
     nio4r (2.3.1)
-    nokogiri (1.10.1)
+    nokogiri (1.10.2)
       mini_portile2 (~> 2.4.0)
     parallel (1.17.0)
     parser (2.6.2.1)

--- a/lib/token_validator/token_service.rb
+++ b/lib/token_validator/token_service.rb
@@ -115,7 +115,7 @@ class TokenValidator::TokenService
 
   def valid_url?(url)
     uri = URI.parse(url)
-    (uri.is_a?(URI::HTTPS) || (uri.is_a?(URI::HTTP) && (Rails.env.development? || Rails.env.test?))) && uri.host.present?
+    (uri.is_a?(URI::HTTPS) || (uri.is_a?(URI::HTTP) && !Rails.env.production?)) && uri.host.present?
   end
 
   def valid_issuer?

--- a/lib/token_validator/version.rb
+++ b/lib/token_validator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TokenValidator
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end


### PR DESCRIPTION
*Why?*

With the pending addition of the e2e environment we need to change the way the check is made for URL schemes

*How?*

Instead of checking for all environments other than production check for !production

*Risks*

None

*Requested Reviewers*

