### PR TITLE
Update ruby version to 2.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     parallelism: 1
     working_directory: ~/token_validator
     docker:
-      - image: circleci/ruby:2.6.5
+      - image: circleci/ruby:2.7.0
 
     steps:
       - checkout

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
     - node_modules/**/*
     - output/**/*
     - vendor/**/*
-  TargetRubyVersion: 2.6.5
+  TargetRubyVersion: 2.7.0
   RSpec:
     Patterns:
       - _spec.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ruby '2.6.5'
+ruby '2.7.0'
 
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.6.5p114
+   ruby 2.7.0p0
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    token_validator (0.5.1)
+    token_validator (0.6.0)
       jose
       json-jwt
       jwt

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
       json
       simplecov
       url
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
@@ -128,7 +128,7 @@ GEM
     minitest (5.14.0)
     netrc (0.11.0)
     nio4r (2.5.2)
-    nokogiri (1.10.7)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     parallel (1.19.1)
     parser (2.7.0.2)
@@ -218,7 +218,7 @@ GEM
     unf_ext (0.0.7.6)
     unicode-display_width (1.6.1)
     url (0.3.2)
-    webmock (3.8.1)
+    webmock (3.8.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)

--- a/README.md
+++ b/README.md
@@ -41,25 +41,25 @@ Development on this project should occur on separate feature branches and pull r
 
 This application requires:
 
-* Ruby version: 2.7.0
+*   Ruby version: 2.7.0
 
 If you do not have Ruby installed, it is recommended you use ruby-install and chruby to manage Ruby versions.
 
-```
+```bash
 brew install ruby-install chruby
 ruby-install ruby 2.7.0
 ```
 
 Add the following lines to ~/.bash_profile:
 
-```
+```bash
 source /usr/local/opt/chruby/share/chruby/chruby.sh
 source /usr/local/opt/chruby/share/chruby/auto.sh
 ```
 
 Set Ruby version to 2.7.0:
 
-```
+```bash
 source ~/.bash_profile
 chruby 2.7.0
 ```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,33 @@ $ gem install token_validator
 ## Development
 Development on this project should occur on separate feature branches and pull requests should be submitted. When submitting a pull request, the pull request comment template should be filled out as much as possible to ensure a quick review and increase the likelihood of the pull request being accepted.
 
+### Ruby
+
+This application requires:
+
+* Ruby version: 2.7.0
+
+If you do not have Ruby installed, it is recommended you use ruby-install and chruby to manage Ruby versions.
+
+```
+brew install ruby-install chruby
+ruby-install ruby 2.7.0
+```
+
+Add the following lines to ~/.bash_profile:
+
+```
+source /usr/local/opt/chruby/share/chruby/chruby.sh
+source /usr/local/opt/chruby/share/chruby/auto.sh
+```
+
+Set Ruby version to 2.7.0:
+
+```
+source ~/.bash_profile
+chruby 2.7.0
+```
+
 ### Running Tests
 ```ruby
 rspec # Without code coverage

--- a/lib/token_validator/version.rb
+++ b/lib/token_validator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TokenValidator
-  VERSION = '0.5.1'
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
*Related Defect(s), Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/7793

*Why?*

Keeping our codebase up to date is part of the culture here at Ario.

*How?*

Update from 2.6.3 to 2.7.0 via `bundle update --ruby`
Address deprecation warnings by running `bundle update mime-types`

*How did this defect occur?*

N/A

*Risks*

Low.

*Requested Reviewers*

@gregfletch @deankeo 

### Note for reviewers

This PR will only be merged when all the ruby 2.7.0 PRs are approved.

### Note for developers

This change requires you to run the following on MacOS
```bash
brew update
brew upgrade
ruby-install ruby 2.7.0
```

and add `chruby 2.7.0` in `~/.bash_profile`, and then run
```bash
source ~/.bash_profile
```

you also may have to run `gem install bundler:2.1.2`