### PR TITLE
Fix rubocop config warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,7 +32,7 @@ Security/YAMLLoad:
 Security/JSONLoad:
   Enabled: true
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 160
 
 Metrics/ClassLength:
@@ -58,3 +58,12 @@ RSpec/MultipleExpectations:
 
 RSpec/ExampleLength:
   Max: 10
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true


### PR DESCRIPTION
*Related Defect(s), Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/8729

*Why?*

We were getting annoying warnings about cops not being enabled.

*How?*

Update the rubocop config to enable the new cops.

*How did this defect occur?*

Rubocop was updated by dependabot and this was not noticed at first

*Risks*

Low

*Requested Reviewers*

@DominicRoyStang @dragoszt 
