### PR TITLE
Update rubocop config to remove warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,3 +67,9 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true


### PR DESCRIPTION
*Related Defect(s), Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/9255

*Why?*

Rubocop was updated and added new cops and was printing warning messages to enable/disable the new cops.

*How?*

Enable the new cops to make the warnings go away.

*How did this defect occur?*

N/A

*Risks*

Low

*Requested Reviewers*

@bcarr092 @dragoszt 
