### PR TITLE
~> 0.6.3 handle blank scopes with default deny

### DIFF
--- a/lib/token_validator/token_service.rb
+++ b/lib/token_validator/token_service.rb
@@ -51,6 +51,7 @@ class TokenValidator::TokenService
 
   def valid_scope?
     raise InvalidScope, 'Missing scopes' unless decoded_jwt.key?('scopes')
+    return true if @expected_scopes.blank?
 
     valid = false
     @expected_scopes.each do |scope|

--- a/lib/token_validator/version.rb
+++ b/lib/token_validator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TokenValidator
-  VERSION = '0.6.2'
+  VERSION = '0.6.3'
 end

--- a/spec/token_validator/token_service_spec.rb
+++ b/spec/token_validator/token_service_spec.rb
@@ -128,6 +128,18 @@ RSpec.describe TokenValidator::TokenService, type: :request do
     expect(service.valid_access_token?).to be true
   end
 
+  it 'with valid access token (no scopes expected, none given) is valid' do
+    stub_jwks_response
+    service = described_class.new(access_token(scopes: []), [])
+    expect(service.valid_access_token?).to be true
+  end
+
+  it 'with valid access token (no scopes expected, some given) is valid' do
+    stub_jwks_response
+    service = described_class.new(access_token(scopes: ['idp:api']), [])
+    expect(service.valid_access_token?).to be true
+  end
+
   it "with invalid access token (signature) is not valid" do
     stub_jwks_response
     service = described_class.new(access_token(valid_signature: false), expected_scopes)


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/12024

*Why?*

Part of the change of the previous version (https://github.com/Zetatango/token_validator/pull/144) made scope checking default-deny instead of default-accept.  

Overlooked the degenerate case when expected_scopes is blank.  Since we are now starting `valid = false` and looking for non empty intersection to make it `true`, we end up returning `false` when there are no expected_scopes.

This is causing a number of failed tests when trying to upgrade the gem in Wile (see https://github.com/Zetatango/wile_e/pull/1443) where there are empty scopes in tests for malformed URLs or missing required parameters, which should be returning `not_found` but were now returning `unauthorized`.

*How?*

Add a `return true` if there are no scopes expected.

*Risks*

Low.  This is an edge case.  All actual legitimate requests to API endpoints we use require one or more scopes.

*Requested Reviewers*

Brent, Dragos
